### PR TITLE
Back: Fix Attendance and Subject migration

### DIFF
--- a/backend/prisma/migrations/20240912014436_subject_up/migration.sql
+++ b/backend/prisma/migrations/20240912014436_subject_up/migration.sql
@@ -7,9 +7,9 @@
 
 */
 -- DropIndex
-DROP INDEX "Subject_name_divisionId_key";
+DROP INDEX IF EXISTS "Subject_name_divisionId_key";
 
 -- AlterTable
-ALTER TABLE "Subject" ADD COLUMN     "description" VARCHAR(256) NOT NULL,
-ADD COLUMN     "scheduleEnd" VARCHAR(128) NOT NULL,
-ADD COLUMN     "scheduleInit" VARCHAR(128) NOT NULL;
+ALTER TABLE "Subject" ADD COLUMN IF NOT EXISTS     "description" VARCHAR(256) NOT NULL,
+ADD COLUMN IF NOT EXISTS    "scheduleEnd" VARCHAR(128) NOT NULL,
+ADD COLUMN  IF NOT EXISTS   "scheduleInit" VARCHAR(128) NOT NULL;


### PR DESCRIPTION
In order to prevent conflicts with existing database objects. This code verify if Tables, indexes and constraints exists before  attempting to create them.

I know manual modifications to prisma migrations are not ideal but...